### PR TITLE
README: add details about the .env configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@ prod description
 
 ## Local development
 
+### Configure the env file
+
+```
+$ cp env.example .env
+```
+Replace the default values by the ones in Slack.
+
 ```
 $ cd docker/
 $ docker-compose build


### PR DESCRIPTION
If the .env file doesn't exist, the docker-compose build will fail with this command:
ERROR: Couldn't find env file: response/.env

Fix #16