### PR TITLE
#28 add status update in thread 

### DIFF
--- a/response/slack/incident_commands/incident_commands.py
+++ b/response/slack/incident_commands/incident_commands.py
@@ -1,11 +1,14 @@
 import logging
 from datetime import datetime
 
+from django.conf import settings
 from response.core.models import Action, ExternalUser, Incident, StatusUpdate
 from response.slack.cache import get_user_profile
 from response.slack.client import SlackError
 from response.slack.decorators.incident_command import (
     __default_incident_command, get_help)
+from response.slack.block_kit import (Actions, Button, Divider, Message,
+                                      Section, Text)
 from response.slack.models import CommsChannel, HeadlinePost
 from response.slack.reference_utils import reference_to_id
 from response.zoom.zoom import Zoom
@@ -26,6 +29,24 @@ def add_status_update(incident: Incident, user_id: str, message: str):
         external_id=user_id, display_name=name
     )
     StatusUpdate(incident=incident, text=message, user=action_reporter).save()
+    msg = Message()
+    msg.add_block(
+            Section(
+                block_id="update",
+                text=Text(
+                    f":warning: *Update:*\n{message} "
+                ),
+            )
+        )
+    comms_channel = CommsChannel.objects.get(incident=incident)
+    ts = HeadlinePost.objects.get(incident=incident).message_ts
+    msg.send(comms_channel.channel_id, None)
+    settings.SLACK_CLIENT.send_message(
+            settings.INCIDENT_CHANNEL_ID,":warning: *Update*: "+message , thread_ts=ts
+        )
+
+
+    #comms_channel.post_in_channel(msg)
     return True, None
 
 @__default_incident_command(["lead"], helptext="Assign someone as the incident lead")

--- a/response/slack/models/headline_post.py
+++ b/response/slack/models/headline_post.py
@@ -107,7 +107,7 @@ class HeadlinePost(models.Model):
         msg.add_block(
             Section(
                 block_id="incident_doc",
-                text=Text(f"📄 Document: <{doc_url}|Incident {self.incident.pk}>"),
+                text=Text(f"📄 Status: <{doc_url}|Incident {self.incident.pk}>"),
             )
         )
 


### PR DESCRIPTION
#28 
- send status update in a thread message on the main incident channel
- send status update in a message in the incident room
- renamed Document: with Status: